### PR TITLE
fix inspectrum build by adding liquid-dsp

### DIFF
--- a/liquid-dsp.lwr
+++ b/liquid-dsp.lwr
@@ -19,9 +19,8 @@
 
 category: application
 depends:
-- liquid-dsp
-- qt5
-description: recorded data browser
+- fftw
+description: digital signal processing library for software-defined radios
 gitbranch: master
-inherit: cmake
-source: git+https://github.com/miek/inspectrum.git
+inherit: bootstrapautoconf
+source: git+https://github.com/jgaeddert/liquid-dsp.git


### PR DESCRIPTION
Note that building liquid-dsp depends on
https://github.com/gnuradio/pybombs/pull/370