### PR TITLE
Addition of a recipe for Multi-RTL

### DIFF
--- a/multi-rtl.lwr
+++ b/multi-rtl.lwr
@@ -1,0 +1,35 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+configuredir: build
+depends:
+- gnuradio
+- gr-osmosdr
+- scipy
+- liblog4cpp
+description: Multi-rtl is a GNU Radio block that transforms cheap multiple RTL-SDR receivers into multi-channel receiver
+gitbranch: master
+inherit: cmake
+install: 'make install
+  ldconfig || true
+  '
+installdir: build
+makedir: build
+source: git+https://github.com/ptrkrysik/multi-rtl.git


### PR DESCRIPTION
Multi-RTL is a GNU Radio block written by me that transforms cheap multiple RTL-SDR receivers into multi-channel receiver. For more info about it look here:
https://github.com/ptrkrysik/multi-rtl/
https://ptrkrysik.github.io/