### PR TITLE
DSP library and command-line tool for Software Defined Radio

### DIFF
--- a/csdr.lwr
+++ b/csdr.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: application
+depends:
+- fftw
+description: simple DSP library and command-line tool for Software Defined Radio
+gitbranch: master
+inherit: empty
+source: git+https://github.com/ckuethe/csdr


### PR DESCRIPTION
At the moment this uses my fork until simonyiszk/csdr#12 is merged
which allows installing to alternate prefixes (as you would do with
PyBOMBS)