### PR TITLE
Update for the new version of gr-dsd.

### DIFF
--- a/gr-dsd.lwr
+++ b/gr-dsd.lwr
@@ -19,37 +19,10 @@
 
 category: common
 depends:
-- mbelib
 - gnuradio
 - libsndfile
+- libitpp
 description: GNU Radio block for Digital Speech Decoder
 gitbranch: master
 inherit: cmake
-install: 'make install
-
-
-  mkdir -p $prefix/include/dsd
-
-
-  cp -v ../dsd/dsd.h $prefix/include
-
-  cp -v ../dsd/config.h $prefix/include
-
-  cp -v ../include/dsd_block_ff.h $prefix/include/dsd
-
-  cp -v ../include/dsd_api.h $prefix/include/dsd
-
-  '
 source: git+https://github.com/argilo/gr-dsd.git
-uninstall: 'make uninstall
-
-
-  rm -v $prefix/include/dsd.h || true
-
-  rm -v $prefix/include/config.h || true
-
-  rm -v $prefix/include/dsd/dsd_block_ff.h || true
-
-  rm -v $prefix/include/dsd/dsd_api.h || true
-
-  '


### PR DESCRIPTION
I just rebuilt gr-dsd using gr_modtool (https://github.com/argilo/gr-dsd/commit/23d29f6808207d5aec96aea9ac9349ed6eb0d6ef). This has resulted in new include file paths, so this recipe no longer works.

I'm proposing to remove the `install` and `uninstall` sections as they seem to be unnecessary. Also, mbelib is not a dependency since gr-dsd includes its own copy of mbelib.

@mbr0wn
