### PR TITLE
gr-pager: Drop gr-filter and gr-analog dependencies

### DIFF
--- a/gr-pager.lwr
+++ b/gr-pager.lwr
@@ -20,8 +20,6 @@
 category: common
 depends:
 - gnuradio
-- gr-filter
-- gr-analog
 description: Motorola FLEX Receiver
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
These are provided by gnuradio and only cause pybombs to fail
dependency resolution. Unfortunately it looks like the fix had been
lying around uncommitted in my local tree since the original pull
request!

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>