### PR TITLE
Add recipe for gr-outernet

### DIFF
--- a/gr-kiss.lwr
+++ b/gr-kiss.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+description: GNU Radio blocks for KISS and AX.25
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/daniestevez/gr-kiss.git

--- a/gr-outernet.lwr
+++ b/gr-outernet.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+- gr-kiss
+description: Outernet decoder
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/daniestevez/gr-outernet.git


### PR DESCRIPTION
This patch adds a recipe to build [gr-outernet](https://github.com/daniestevez/gr-outernet), which provides blocks to decode packets from [Outernet](https://outernet.is/).

For more information about the receiver, take a look at Daniel Estévez' article on the [GNU Radio Blog](http://gnuradio.org/blog/reverse-engineering-outernet/) which covers how the receiver works.