### PR TITLE
Updating recipe for gr-signal_exciter. 

### DIFF
--- a/libboost-random.lwr
+++ b/libboost-random.lwr
@@ -17,14 +17,9 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends:
-- boost
-- libboost-random
-- gnuradio
-- libconfig
-- libjsoncpp
-description: Tools for efficient generation of wideband populated spectrum
-gitbranch: master
-inherit: cmake
-source: git+https://github.com/gr-vt/gr-signal_exciter.git
+category: baseline
+description: compiled boost random library
+depends: null
+inherit: autoconf
+satisfy:
+  deb: libboost-random-dev

--- a/libjsoncpp.lwr
+++ b/libjsoncpp.lwr
@@ -17,14 +17,10 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends:
-- boost
-- libboost-random
-- gnuradio
-- libconfig
-- libjsoncpp
-description: Tools for efficient generation of wideband populated spectrum
-gitbranch: master
-inherit: cmake
-source: git+https://github.com/gr-vt/gr-signal_exciter.git
+category: baseline
+description: library for processing json files
+depends: null
+inherit: autoconf
+satisfy:
+  deb: libjsoncpp-dev
+  rpm: libjsoncpp-devel


### PR DESCRIPTION
gr-signal_exciter is undergoing updates and parser shift which require new libraries be made available. First libboost-random is needed such that boost::random_device is available (not available by default on 14.04 at the very least). Second switching from libconfig to libjsoncpp to make configuration files more human friendly.

Please augment with rpm library for libboost-random, couldn't figure that one out.