### PR TITLE
Updated gr-signal_exciter.lwr

### DIFF
--- a/gr-signal_exciter.lwr
+++ b/gr-signal_exciter.lwr
@@ -22,7 +22,6 @@ depends:
 - boost
 - libboost-random
 - gnuradio
-- libconfig
 - libjsoncpp
 description: Tools for efficient generation of wideband populated spectrum
 gitbranch: master

--- a/libboost-random.lwr
+++ b/libboost-random.lwr
@@ -17,14 +17,9 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends:
-- boost
-- libboost-random
-- gnuradio
-- libconfig
-- libjsoncpp
-description: Tools for efficient generation of wideband populated spectrum
-gitbranch: master
-inherit: cmake
-source: git+https://github.com/gr-vt/gr-signal_exciter.git
+category: baseline
+description: compiled boost random library
+depends: null
+inherit: autoconf
+satisfy:
+  deb: libboost-random-dev

--- a/libjsoncpp.lwr
+++ b/libjsoncpp.lwr
@@ -17,14 +17,10 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
-depends:
-- boost
-- libboost-random
-- gnuradio
-- libconfig
-- libjsoncpp
-description: Tools for efficient generation of wideband populated spectrum
-gitbranch: master
-inherit: cmake
-source: git+https://github.com/gr-vt/gr-signal_exciter.git
+category: baseline
+description: library for processing json files
+depends: null
+inherit: autoconf
+satisfy:
+  deb: libjsoncpp-dev
+  rpm: libjsoncpp-devel


### PR DESCRIPTION
Updates to the gr-signal_exciter OOTM have caused changes to the recipe file.
In addition two libraries are needed (libboost-random, libjsoncpp), and one removed (libconfig).
The merge request includes the recipe files needed for the new libraries (Debian focused).