### PR TITLE
switch to upstream repo

### DIFF
--- a/csdr.lwr
+++ b/csdr.lwr
@@ -23,4 +23,4 @@ depends:
 description: simple DSP library and command-line tool for Software Defined Radio
 gitbranch: master
 inherit: empty
-source: git+https://github.com/ckuethe/csdr
+source: git+https://github.com/simonyiszk/csdr


### PR DESCRIPTION
https://github.com/simonyiszk/csdr/pull/12 adds support for
a $PREFIX variable to allow installation into an arbitrary
destination (like a pybombs prefix)