### PR TITLE
Add gr-nrsc5.

### DIFF
--- a/gr-nrsc5.lwr
+++ b/gr-nrsc5.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+description: HD Radio transmitter for GNU Radio
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/argilo/gr-nrsc5.git


### PR DESCRIPTION
I recently put together an NRSC-5 (HD Radio) transmitter for GNU Radio: https://github.com/argilo/gr-nrsc5. It doesn't implement 100% of the standard yet, but it's got enough to encode & transmit multiple audio channels, as well as metadata about the station and the audio that is currently playing.

I tested out this recipe, and it seems to install it properly.