### PR TITLE
Add recipe for gr-corrsounder

### DIFF
--- a/gr-corrsounder.lwr
+++ b/gr-corrsounder.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+- scipy
+description: Correlative Channel Sounder for Fast Time Variance
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/inIT-HF/gr-corrsounder.git


### PR DESCRIPTION
This module adds a channel sounder with correlative sequences. Currently, MLS and FZC sequences are targeted.