### PR TITLE
Use the official libfec repository

### DIFF
--- a/libfec.lwr
+++ b/libfec.lwr
@@ -21,7 +21,5 @@ category: common
 depends:
 description: Phil Karn's libfec
 gitbranch: master
-inherit: autoconf
-source: git+https://github.com/daniestevez/libfec
-
-
+inherit: cmake
+source: git+https://github.com/quiet/libfec


### PR DESCRIPTION
Let's use the official libfec repository since the patch in daniestevez/libfec has already been in there for months

/cc @anuraaga