### PR TITLE
Version: fix Cython minimum version

### DIFF
--- a/cython.lwr
+++ b/cython.lwr
@@ -23,5 +23,5 @@ depends:
 - numpy
 inherit: distutils
 satisfy:
-  deb: cython >= 3.0
+  deb: cython >= 0.26
 source: git+https://github.com/cython/cython.git


### PR DESCRIPTION
This commit bumps the minimum version for Cython to 0.26 to allow
repo installs for e.g. Ubuntu 18.04.