### PR TITLE
update branches of 802.15.4, keyfob, and rstt

### DIFF
--- a/gr-ieee-802154.lwr
+++ b/gr-ieee-802154.lwr
@@ -23,6 +23,6 @@ depends:
 - uhd
 - gr-foo
 description: IEEE 802.15.4 ZigBee Transceiver
-gitbranch: master
+gitbranch: maint-3.7
 inherit: cmake
 source: git+https://github.com/bastibl/gr-ieee802-15-4.git

--- a/gr-keyfob.lwr
+++ b/gr-keyfob.lwr
@@ -21,6 +21,6 @@ category: common
 depends:
 - gnuradio
 description: Transceiver for Hella wireless car key fobs
-gitbranch: master
+gitbranch: maint-3.7
 inherit: cmake
 source: git+https://github.com/bastibl/gr-keyfob.git

--- a/gr-rstt.lwr
+++ b/gr-rstt.lwr
@@ -21,6 +21,6 @@ category: common
 depends:
 - gnuradio
 description: Vaisala Radiosonde Telemetry Receiver
-gitbranch: master
+gitbranch: maint-3.7
 inherit: cmake
 source: git+https://github.com/bastibl/gr-rstt.git


### PR DESCRIPTION
I ported my modules and switched over to the proposed dev scheme for 3.8, i.e., the legacy branch was renamed to *maint-3.7*.