### PR TITLE
Updated version of pyconstruct to 2.9

### DIFF
--- a/pyconstruct.lwr
+++ b/pyconstruct.lwr
@@ -21,8 +21,8 @@ category: baseline
 depends:
 - python
 satisfy:
-  deb: python-construct >= 2.8
-  rpm: python-construct >= 2.8
-  python: construct.version >= 2.8
-source: https://github.com/construct/construct/archive/v2.8.12.tar.gz
+  deb: python-construct >= 2.9
+  rpm: python-construct >= 2.9
+  python: construct.version >= 2.9
+source: https://github.com/construct/construct/archive/v2.9.45.tar.gz
 


### PR DESCRIPTION
pyconstruct recipe has been updated to install version 2.9.45
gr-satellites now needs pyconstruct version >= 2.9