### PR TITLE
gr-ham: Remove dependency on gr-compat

### DIFF
--- a/gr-ham.lwr
+++ b/gr-ham.lwr
@@ -20,7 +20,6 @@
 category: common
 depends:
 - gnuradio
-- gr-compat
 description: GNU Radio blocks useful for amateur radio
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
Currently gr-ham fails to install on GNU Radio 3.8 because the recipe lists a dependency on gr-compat. The gr-ham module has no dependency on gr-compat, so I'm removing it from the recipe.