### PR TITLE
Add libfreesrp and libmirisdr

### DIFF
--- a/libfreesrp.lwr
+++ b/libfreesrp.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: hardware
+depends:
+- libusb
+description: Library for interfacing with FreeSRP devices
+inherit: cmake
+satisfy:
+  deb: libfreesrp0 && libfreesrp-dev
+source: git+https://github.com/myriadrf/libfreesrp

--- a/libmirisdr.lwr
+++ b/libmirisdr.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: hardware
+depends:
+- libusb
+description: Library for interfacing with Mirics devices
+inherit: cmake
+satisfy:
+  deb: libmirisdr0 && libmirisdr-dev
+source: git+https://git.osmocom.org/libmirisdr


### PR DESCRIPTION
These boards are supported by gr-osmosdr, so it would be useful to have recipes for them.

I had originally included these recipes in https://github.com/gnuradio/gr-recipes/pull/188 but moved them to gr-etcetera at [@mbr0wn's suggestion](https://github.com/gnuradio/gr-recipes/pull/188#issuecomment-665492350) since these libraries are probably not widely used.