### PR TITLE
Add gr-gmuground.lwr

### DIFF
--- a/gr-gmuground.lwr
+++ b/gr-gmuground.lwr
@@ -30,7 +30,6 @@ depends:
 - libfec
 - pyconstruct
 - swig
-- requests
 description: A collection of OOT modules for developing an amateur satellite communications ground station. 
 gitbranch: maint-3.8
 inherit: cmake

--- a/gr-gmuground.lwr
+++ b/gr-gmuground.lwr
@@ -1,0 +1,37 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+- gr-limesdr
+- gr-satellites
+- gr-gpredict-doppler
+- gr-filerepeater
+- gr-fosphor
+- gr-display
+- gr-guiextra
+- libfec
+- construct
+- swig
+- requests
+description: A collection of OOT modules for developing an amateur satellite communications ground station. 
+gitbranch: maint-3.8
+inherit: cmake
+source: git+https://github.com/wbarnha/gr-gmuground.git

--- a/gr-guiextra.lwr
+++ b/gr-guiextra.lwr
@@ -20,6 +20,7 @@
 category: common
 depends:
 - gnuradio
+- gr-lfast
 description: Control File Source replay with repeat delays and counts
 gitbranch: master
 inherit: cmake

--- a/gr-guiextra.lwr
+++ b/gr-guiextra.lwr
@@ -20,18 +20,7 @@
 category: common
 depends:
 - gnuradio
-- gr-limesdr
-- gr-satellites
-- gr-gpredict-doppler
-- gr-filerepeater
-- gr-fosphor
-- gr-display
-- gr-guiextra
-- libfec
-- pyconstruct
-- swig
-- requests
-description: A collection of OOT modules for developing an amateur satellite communications ground station. 
-gitbranch: maint-3.8
+description: Control File Source replay with repeat delays and counts
+gitbranch: master
 inherit: cmake
-source: git+https://github.com/wbarnha/gr-gmuground.git
+source: git+https://github.com/ghostop14/gr-guiextra.git


### PR DESCRIPTION
Moved from gr-recipes.

I'd like to add this to gr-etcetera so that gr-gmuground can appear on cgran.org and make future amateur satellite communications simpler for some people. There's a laundry list of dependencies I have developed my repository around, so I just wrote a Shell script to simplify the process. There's also some blacklisted dependencies, but I've included them anyway.