### PR TITLE
Add gr-lora2

### DIFF
--- a/gr-lora2.lwr
+++ b/gr-lora2.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+description: LoRA LPWAN PHY
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/rpp0/gr-lora.git


### PR DESCRIPTION
This adds a recipe for https://github.com/rpp0/gr-lora. I added a "2" to the name since there's already a gr-lora recipe for https://github.com/BastilleResearch/gr-lora.