### PR TITLE
Update source URL for gr-pager.

### DIFF
--- a/gr-pager.lwr
+++ b/gr-pager.lwr
@@ -21,6 +21,6 @@ category: common
 depends:
 - gnuradio
 description: Motorola FLEX Receiver
-gitbranch: master
+gitbranch: main
 inherit: cmake
-source: git+https://github.com/amboar/gr-pager.git
+source: git+https://github.com/troycurtisjr/gr-pager.git


### PR DESCRIPTION
Andrew Jeffery (@amboar ) has stated he doesn't have the capacity to maintain gr-pager repo any
longer, so we can point to my clone now that I have it working with 3.8.