### PR TITLE
Add gr-pipe

### DIFF
--- a/gr-pipe.lwr
+++ b/gr-pipe.lwr
@@ -1,0 +1,26 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+description: Collection of blocks for using any program as a source, sink or filter using Unix pipes.
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/jolivain/gr-pipe.git


### PR DESCRIPTION
gr-pipe is a set GNU Radio block for using any program as a source,
sink or filter by using standard Unix I/O pipes.

See: https://github.com/jolivain/gr-pipe

Signed-off-by: Julien Olivain <juju@cotds.org>