### PR TITLE
Fix malformed depends

### DIFF
--- a/apr.lwr
+++ b/apr.lwr
@@ -19,7 +19,6 @@
 
 category: baseline
 description: Apache Portable Runtime
-depends: null
 inherit: autoconf
 satisfy:
   deb: libapr1-dev

--- a/libboost-random.lwr
+++ b/libboost-random.lwr
@@ -19,7 +19,6 @@
 
 category: baseline
 description: compiled boost random library
-depends: null
 inherit: autoconf
 satisfy:
   deb: libboost-random-dev

--- a/libconfig.lwr
+++ b/libconfig.lwr
@@ -19,7 +19,6 @@
 
 category: baseline
 description: library for processing configuration files
-depends: null
 inherit: autoconf
 satisfy:
   deb: libconfig-dev

--- a/libjsoncpp.lwr
+++ b/libjsoncpp.lwr
@@ -19,7 +19,6 @@
 
 category: baseline
 description: library for processing json files
-depends: null
 inherit: autoconf
 satisfy:
   deb: libjsoncpp-dev


### PR DESCRIPTION
I ran `pybombs lint` against everything in gr-etcetera, and it complained loudly about some broken `depends`:

```
[VERY BAD] Dependencies is not a list: None
```

It looks like recipes that don't have any dependencies should not have a `depends` property, so I've removed them here.