### PR TITLE
commpy: Remove confusing commented entry

### DIFF
--- a/scikit-commpy.lwr
+++ b/scikit-commpy.lwr
@@ -23,7 +23,6 @@ depends:
 - python
 - scipy
 - numpy
-#- commpy
 satisfy:
   pip: scikit-commpy >= 0.3
 #  deb: scikit-commpy >= 0.3


### PR DESCRIPTION
We want to install `scikit-commpy` and `commpy` should not be a dependency. In fact, it never was.

This does not solve the issue that pybombs does not recognize a scikit-commpy installation via pip. 