### PR TITLE
gr-gfdm: Update recipe

### DIFF
--- a/gr-gfdm.lwr
+++ b/gr-gfdm.lwr
@@ -21,8 +21,6 @@ category: common
 inherit: cmake
 depends:
 - gnuradio
-- python
-- cython
 - scipy
 - scikit-commpy
 source: git+https://github.com/jdemel/gr-gfdm.git


### PR DESCRIPTION
Cython is no longer needed to build gr-gfdm (or use it). Thus, it is removed from the recipe.