### PR TITLE
latency: Add recipe for gr-latency

### DIFF
--- a/gr-latency.lwr
+++ b/gr-latency.lwr
@@ -1,0 +1,32 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+inherit: cmake
+depends:
+- gnuradio
+- python
+source: https://github.com/ant-uni-bremen/gr-latency.git
+gitbranch: master
+gitargs: --recursive
+vars:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs "
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix $config_opt
+install:
+    make install


### PR DESCRIPTION
gr-latency is a tool to measure flowgraph latency. Aka the time it takes for a sample to propagate through.