### PR TITLE
polar: Add OOT for polar codes

### DIFF
--- a/fmt.lwr
+++ b/fmt.lwr
@@ -1,0 +1,25 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+description: Advanced C++ string formatting to become std::format 
+inherit: autoconf
+satisfy:
+  deb: libfmt-dev
+

--- a/gr-polarwrap.lwr
+++ b/gr-polarwrap.lwr
@@ -1,0 +1,33 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+inherit: cmake
+depends:
+- gnuradio
+- python
+- polar-codes
+source: https://github.com/jdemel/gr-polarwrap.git
+gitbranch: master
+gitargs: --recursive
+vars:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs "
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix $config_opt
+install:
+    make install

--- a/polar-codes.lwr
+++ b/polar-codes.lwr
@@ -1,0 +1,37 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+inherit: cmake
+depends:
+- python
+- numpy
+- doxygen
+- cppunit
+- ssl
+- fmt
+- tclap
+source: https://github.com/ant-uni-bremen/polar-codes.git
+gitbranch: master
+gitargs: --recursive
+vars:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs "
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix $config_opt
+install:
+    make install

--- a/tclap.lwr
+++ b/tclap.lwr
@@ -1,0 +1,25 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+description: C++ command line argument helpers
+inherit: autoconf
+satisfy:
+  deb: libtclap-dev
+


### PR DESCRIPTION
This OOT is a wrapper for `polar-codes` a library with optimized polar encoders and decoders. It depends on some more libraries that are not yet available with the standard PyBOMBS recipes.
fmt.lwr installes FMTlib which may be very useful to move towards `std::format` and purge `boost::format`.
tclap is a tool to create a command line interface in C++.