### PR TITLE
Add missing dependency to gr-gsm

### DIFF
--- a/gr-gsm.lwr
+++ b/gr-gsm.lwr
@@ -25,6 +25,7 @@ depends:
 - scipy
 - liblog4cpp
 - libosmocore
+- cppunit
 description: Gnuradio blocks and tools for receiving GSM transmissions
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
Adds cppunit as a dependency to gr-gsm, which is apparently required (I got an error message while trying to install gr-gsm without this patch).