### PR TITLE
dump1090: use flightaware repo

### DIFF
--- a/dump1090.lwr
+++ b/dump1090.lwr
@@ -27,7 +27,7 @@ builddir: .
 installdir: .
 make: 'make'
 install: 'cp dump1090 view1090 $prefix/bin && mkdir -p $prefix/share/dump1090 && cp -r public_html $prefix/share/dump1090'
-source: git+https://github.com/mutability/dump1090.git
+source: git+https://github.com/flightaware/dump1090.git
 uninstall: 'rm $prefix/bin/dump1090 $prefix/bin/view1090 && rm -r $prefix/share/dump1090'
 vars:
   config_opt: PREFIX=$prefix


### PR DESCRIPTION
mutability repo is no longer maintained and says to use flightaware repo

Signed-off-by: Jeff Long <willcode4@gmail.com>