### PR TITLE
Changed master reference to main for gr-mixalot

### DIFF
--- a/gr-mixalot.lwr
+++ b/gr-mixalot.lwr
@@ -23,6 +23,6 @@ depends:
 - gr-osmosdr
 - libitpp
 description: GNU Radio pager encoder
-gitbranch: master
+gitbranch: main
 inherit: cmake
 source: git+https://github.com/unsynchronized/gr-mixalot.git


### PR DESCRIPTION
Current recipe is broken, will fail with `fatal: Remote branch master not found in upstream origin`.