### PR TITLE
Update osmocom.org git URLs

### DIFF
--- a/libmirisdr.lwr
+++ b/libmirisdr.lwr
@@ -24,4 +24,4 @@ description: Library for interfacing with Mirics devices
 inherit: cmake
 satisfy:
   deb: libmirisdr0 && libmirisdr-dev
-source: git+https://git.osmocom.org/libmirisdr
+source: git+https://gitea.osmocom.org/sdr/libmirisdr.git


### PR DESCRIPTION
Osmocom recently migrated to Gitea, so their repositories have new URLs. HTTP forwarding is working for now, but we may as well update recipes to use the new addresses.