### PR TITLE
Add recipes for DSDcc and gr-dsdcc

### DIFF
--- a/dsdcc.lwr
+++ b/dsdcc.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+depends:
+- mbelib
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/f4exb/dsdcc.git
+vars:
+  config_opt: ' -DUSE_MBELIB=ON '

--- a/gr-dsdcc.lwr
+++ b/gr-dsdcc.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+- dsdcc
+description: GNU Radio block for Digital Speech Decoder
+gitbranch: main
+inherit: cmake
+source: git+https://github.com/argilo/gr-dsdcc.git


### PR DESCRIPTION
I recently made a GNU Radio block (https://github.com/argilo/gr-dsdcc) that encapsulates DSDcc (https://github.com/f4exb/dsdcc) for receiving digital voice signals. These recipes should allow both to be installed. The mbelib dependency already had a recipe.