### PR TITLE
Add liquid-dsp as a depedency of gr-lora2

### DIFF
--- a/gr-lora2.lwr
+++ b/gr-lora2.lwr
@@ -20,6 +20,7 @@
 category: common
 depends:
 - gnuradio
+- liquid-dsp
 description: LoRA LPWAN PHY
 gitbranch: master
 inherit: cmake


### PR DESCRIPTION
The gr-lora2 recipe fails to build if liquid-dsp is not installed. Here I've solved that by specifying it as a dependency.