### PR TITLE
gr-m2k: Add recipes for libm2k and gr-m2k.

### DIFF
--- a/gr-m2k.lwr
+++ b/gr-m2k.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+- libm2k
+description: GNU Radio blocks for ADALM2000
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/analogdevicesinc/gr-m2k

--- a/libm2k.lwr
+++ b/libm2k.lwr
@@ -1,0 +1,28 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: hardware
+depends:
+- libiio
+description: Library for interfacing with the ADALM2000 device.
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/analogdevicesinc/libm2k
+vars:
+  config_opt: ' -DENABLE_TOOLS=ON -DINSTALL_UDEV_RULES=OFF '


### PR DESCRIPTION
This adds a new recipe for the gr-m2k module : https://github.com/analogdevicesinc/gr-m2k and its dependency: libm2k - https://github.com/analogdevicesinc/libm2k

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>