### PR TITLE
Add workflow to test building changed recipes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Build Changed Recipes
+
+on:
+  push:
+    paths:
+      - "**.lwr"
+  pull_request:
+    paths:
+      - "**.lwr"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: igorfreire/pybombs-dev:gnuradio310-ubuntu-jammy
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+      - name: Set up local recipe repository
+        env:
+          HOME: /root/
+        run: |
+          git config --global --add safe.directory $PWD
+          pybombs recipes list-repos
+          pybombs recipes remove gr-etcetera
+          pybombs recipes add local .
+          pybombs recipes update
+      - name: Build new/updated recipes (PR)
+        env:
+          HOME: /root/
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git --no-pager diff --name-only ${{ github.head_ref }} $(git merge-base ${{ github.head_ref }} ${{ github.base_ref }}) | \
+          grep .lwr | cut -d'.' -f 1 | \
+          xargs pybombs install
+      - name: Build new/updated recipes (push)
+        env:
+          HOME: /root/
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          git --no-pager diff --name-only ${{ github.ref_name }} $(git merge-base ${{ github.ref_name }} origin/master)
+          git --no-pager diff --name-only ${{ github.ref_name }} $(git merge-base ${{ github.ref_name }} origin/master) | \
+          grep .lwr | cut -d'.' -f 1 | \
+          xargs pybombs install


### PR DESCRIPTION
It would be nice to have a workflow to test whether new/updated recipes build successfully. This PR adds a workflow I have been experimenting with to test a new recipe (gr-dvbs2rx, pushed in another PR).

The current implementation is still based on the [igorfreire/pybombs-dev](https://hub.docker.com/repository/docker/igorfreire/pybombs-dev/general) image on my DockerHub account. However, I also plan on moving this image and the [OOT dev image](https://hub.docker.com/repository/docker/igorfreire/gnuradio-oot-dev/general) I maintain into the gnuradio workspace, as discussed here: https://github.com/gnuradio/gnuradio/issues/6194.

I have tested the given implementation on push events. The job will process the `.lwr` files changed relative to the master branch and call `pybombs install` on them. My next step is to test whether the job is functional on PRs. So the roadmap for this PR is as follows:

- [ ] Confirm the workflow works on pull requests.
- [ ] If agreed, wait until  `igorfreire/pybombs-dev` is moved into `gnuradio/pybombs-dev`.