### PR TITLE
Fix gr-m17 recipe

### DIFF
--- a/gr-m17.lwr
+++ b/gr-m17.lwr
@@ -21,7 +21,8 @@ category: common
 depends:
 - gnuradio
 description: GNU Radio M17 protocol implementation
-gitbranch: master
+gitbranch: main
+gitargs: --recursive
 inherit: cmake
 source: git+https://github.com/M17-Project/gr-m17.git
 vars:


### PR DESCRIPTION
This fixes two problem with the gr-m17 recipe:

* The development branch is now called `main`
* The module fails to build without the required git submodule.