### PR TITLE
gr-m17: Don't override GR_PYTHON_DIR

### DIFF
--- a/gr-m17.lwr
+++ b/gr-m17.lwr
@@ -25,5 +25,3 @@ gitbranch: main
 gitargs: --recursive
 inherit: cmake
 source: git+https://github.com/M17-Project/gr-m17.git
-vars:
-  config_opt: ' -DGR_PYTHON_DIR=$prefix/lib/python3 '


### PR DESCRIPTION
I'm not sure why I included the `GR_PYTHON_DIR` override in #108, but it's not necessary anymore, and in fact now prevents gr-m17 from being installed to the correct location. Let's remove it.