### PR TITLE
gr-ieee-802154: Update to maint-3.10 branch

### DIFF
--- a/gr-ieee-802154.lwr
+++ b/gr-ieee-802154.lwr
@@ -23,6 +23,6 @@ depends:
 - uhd
 - gr-foo
 description: IEEE 802.15.4 ZigBee Transceiver
-gitbranch: maint-3.8
+gitbranch: maint-3.10
 inherit: cmake
 source: git+https://github.com/bastibl/gr-ieee802-15-4.git


### PR DESCRIPTION
GNU Radio 3.10 was released nearly three years ago, so I think it makes sense to update the PyBOMBS recipes that still point at earlier versions.