### PR TITLE
Fix ACARSDEC recipes

### DIFF
--- a/acarsdec.lwr
+++ b/acarsdec.lwr
@@ -23,7 +23,7 @@ category: application
 depends:
 - rtl-sdr
 - libacars
-source: git+https://github.com/ckuethe/acarsdec.git
+source: git+https://github.com/TLeconte/acarsdec.git
 
 vars:
-  config_opt: -Drtl=ON -DLIBACARS=$PYBOMBS_PREFIX/lib/libacars.so -DLIBRTL=$PYBOMBS_PREFIX/lib/librtlsdr.so -DCMAKE_INSTALL_PREFIX=$PYBOMBS_PREFIX -DCMAKE_C_FLAGS="$(pkg-config --cflags --libs librtlsdr libacars) -DRTLMULT=204"
+  config_opt: -Drtl=ON

--- a/libacars.lwr
+++ b/libacars.lwr
@@ -1,0 +1,24 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+description: A library for decoding various ACARS message payloads
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/szpajder/libacars.git


### PR DESCRIPTION
The acarsdec recipe fails to install because its libacars dependency doesn't have a recipe. I've added that here.

Also, the acarsdec recipe points to a fork of https://github.com/TLeconte/acarsdec which is many years out of date. The upstream repository builds fine, so I've pointed the recipe at it. The extra `config_opt` arguments are no longer required.