### PR TITLE
added gr-verilog2

### DIFF
--- a/gr-verilog2.lwr
+++ b/gr-verilog2.lwr
@@ -1,0 +1,28 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+depends:
+- gnuradio
+- numpy
+- verilator
+description: Compiles verilog code to executable GNU Radio blocks on the fly.
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/mmaroti/gr-verilog2.git

--- a/verilator.lwr
+++ b/verilator.lwr
@@ -27,4 +27,4 @@ satisfy:
   pacman: verilator
   port: verilator
   portage: sci-electronics/verilator
-source: wget+https://github.com/verilator/verilator/archive/refs/tags/v4.038.zip
+source: wget+https://github.com/verilator/verilator/archive/refs/tags/v4.038.tar.gz

--- a/verilator.lwr
+++ b/verilator.lwr
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-category: common
+category: baseline
 description: Verilator Tool
 inherit: cmake
 satisfy:

--- a/verilator.lwr
+++ b/verilator.lwr
@@ -1,0 +1,30 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+description: Verilator Tool
+inherit: cmake
+satisfy:
+  deb: verilator
+  rpm: verilator
+  cmd: verilator
+  pacman: verilator
+  port: verilator
+  portage: sci-electronics/verilator
+source: wget+https://github.com/verilator/verilator/archive/refs/tags/v4.038.zip


### PR DESCRIPTION
This module takes a verilog source file and parameter values for the top module and
configures and compiles the module into a loadable dynamic library using verilator.
All of this happens at construction time, so the verilog parameters can be set on
the fly from GRC, and the resulting block can be used as any other gnuradio block.
The verilog code must consume and produce all items using AXI Stream interfaces, and
it can use TDATA, TUSER and TLAST values which are transferred as int32 values.
